### PR TITLE
Use new configuration values for telling if indentation reporting is turned on. Closes #10.

### DIFF
--- a/addon/globalPlugins/indent_nav.py
+++ b/addon/globalPlugins/indent_nav.py
@@ -15,7 +15,10 @@ import addonHandler
 import api
 import controlTypes
 import config
-from config.configFlags import ReportLineIndentation
+try:
+    from config.configFlags import ReportLineIndentation
+except (ImportError, ModuleNotFoundError):
+    pass
 import core
 import ctypes
 from enum import Enum, auto
@@ -38,6 +41,7 @@ import textInfos
 import time
 import tones
 import ui
+import versionInfo
 import wx
 
 try:
@@ -46,6 +50,8 @@ try:
 except AttributeError:
     ROLE_EDITABLETEXT = controlTypes.Role.EDITABLETEXT
     ROLE_TREEVIEWITEM = controlTypes.Role.TREEVIEWITEM
+
+BUILD_YEAR = getattr(versionInfo, "version_year", 2023)
 
 debug = False
 if debug:
@@ -421,7 +427,9 @@ class EditableIndentNav(NVDAObject):
         return len(indent.replace("\t", " " * 4))
 
     def isReportIndentWithTones(self):
-        return config.conf["documentFormatting"]["reportLineIndentation"] >= ReportLineIndentation.TONES
+        if BUILD_YEAR >= 2023:
+            return config.conf["documentFormatting"]["reportLineIndentation"] >= ReportLineIndentation.TONES
+        return config.conf["documentFormatting"]["reportLineIndentationWithTones"]
 
     def crackle(self, levels):
         if self.isReportIndentWithTones():

--- a/addon/globalPlugins/indent_nav.py
+++ b/addon/globalPlugins/indent_nav.py
@@ -15,6 +15,7 @@ import addonHandler
 import api
 import controlTypes
 import config
+from config.configFlags import ReportLineIndentation
 import core
 import ctypes
 from enum import Enum, auto
@@ -420,7 +421,7 @@ class EditableIndentNav(NVDAObject):
         return len(indent.replace("\t", " " * 4))
 
     def isReportIndentWithTones(self):
-        return config.conf["documentFormatting"]["reportLineIndentationWithTones"]
+        return config.conf["documentFormatting"]["reportLineIndentation"] >= ReportLineIndentation.TONES
 
     def crackle(self, levels):
         if self.isReportIndentWithTones():


### PR DESCRIPTION
This works from my testing, although am pretty sure it'll break on older versions of NVDA. I'm not sure how doing stuff based on API versions works in add-ons, but I imagine its not that hard, if you're interested in maintaining backward compatibility. I can most likely make the necessary changes, just didn't yet, as I'm not sure if it's wanted.