### PR TITLE
Make it compatible with Cursor

### DIFF
--- a/addon/globalPlugins/indent_nav/__init__.py
+++ b/addon/globalPlugins/indent_nav/__init__.py
@@ -2114,7 +2114,7 @@ class EditableIndentNav(NVDAObject):
             pass
         try:
             productName = self.appModule.productName or ""
-            return productName.startswith("Visual Studio Code")
+            return productName.startswith("Visual Studio Code") or productName.startswith("Cursor")
         except (AttributeError, NameError):
             return False
 


### PR DESCRIPTION
Following your instruction on the mailing list, I made a change to  `isVscodeApp`, then it started working on Cursor, thank you!

As Cursor is gaining a huge popularity recently, I guess it makes sense to change this globally, so I made a PR.